### PR TITLE
1 fit main content to display in mobile devices

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -85,7 +85,8 @@ main {
   border-radius: 1rem;
   font-size: 1.25rem;
   width: 100%;
-  height: calc(100vh - 20rem);
+  height: calc(100vh - 16.25rem);
+  height: calc(100svh - 16.25rem);
   padding: 1rem;
   resize: none;
   outline: none;


### PR DESCRIPTION
Add the `svh` rule to keep the height of the main content as 100% of the visible area.

1. Use `vh` for compatibility.
1. Use `svh` for fit content as 100%.

Fixes #1.